### PR TITLE
Add failing tests highlighting non conformance with the spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ failure = { version = "0.1", default-features = false, features = ["derive"] }
 reqwest = { version  = "0.11", features = ["stream"] }
 tokio = { version = "1.0", features = ["macros", "rt"] }
 futures = "0.3"
+url = "2.2"
+http = "0.2"

--- a/tests/eventsource-stream.rs
+++ b/tests/eventsource-stream.rs
@@ -1,0 +1,30 @@
+use eventsource_stream::Eventsource;
+use futures::stream::StreamExt;
+use http::response::Builder;
+use reqwest::ResponseBuilderExt;
+use reqwest::Response;
+use url::Url;
+
+#[tokio::test]
+async fn populate_fields() {
+    let url = Url::parse("https://example.com").unwrap();
+    let response = Builder::new()
+        .status(200)
+        .url(url.clone())
+        .body("event: my-event\r\ndata:line1
+data: line2
+:
+id: my-id
+:should be ignored too\rretry:42
+")
+        .unwrap();
+    let response = Response::from(response);
+    let mut stream = response.bytes_stream().eventsource();
+
+    let event = stream.next().await.unwrap().unwrap();
+    assert_eq!("my-event", event.event.unwrap());
+    assert_eq!("line1
+line2", String::from_utf8_lossy(&event.data));
+    assert_eq!("my-id", String::from_utf8_lossy(&event.id.unwrap()));
+    assert_eq!(std::time::Duration::from_millis(42), event.retry.unwrap());
+}


### PR DESCRIPTION
Hi, and thanks for this library.

The current implementation is not compliant with [the specification](https://html.spec.whatwg.org/multipage/server-sent-events.html). I added a failing test highlighting various problems:

* comments trigger parsing errors
* multiline data isn't handled properly
* spaces between the column and the data aren't ignored