### PR TITLE
Support Events outside of HTML spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventsource-stream"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Julian Popescu <jpopesculian@gmail.com>"]
 edition = "2018"
 resolver = "2"
@@ -24,7 +24,7 @@ pin-project-lite = "0.2.8"
 
 [dev-dependencies]
 futures = "0.3"
-http = "0.2"
-reqwest = { version = "0.11", features = ["stream"] }
+http = "1.1"
+reqwest = { version = "0.12", features = ["stream"] }
 tokio = { version = "1.0", features = ["macros", "rt"] }
 url = "2.2"

--- a/examples/custom_eventbuilder.rs
+++ b/examples/custom_eventbuilder.rs
@@ -1,0 +1,140 @@
+use futures::stream::StreamExt;
+use http::response::Builder;
+use reqwest::Response;
+use reqwest::ResponseBuilderExt;
+use std::time::Duration;
+use url::Url;
+
+use eventsource_stream::Eventsource;
+use eventsource_stream::{is_lf, Event, EventBuilder, RawEventLine};
+
+#[derive(Default, Debug)]
+pub struct CustomEventBuilder {
+    event: Event,
+    is_complete: bool,
+}
+
+impl EventBuilder for CustomEventBuilder {
+    /// From the HTML spec
+    ///
+    /// -> If the field name is "event"
+    ///    Set the event type buffer to field value.
+    ///
+    /// -> If the field name is "data"
+    ///    Append the field value to the data buffer, then append a single U+000A LINE FEED (LF)
+    ///    character to the data buffer.
+    ///
+    /// -> If the field name is "id"
+    ///    If the field value does not contain U+0000 NULL, then set the last event ID buffer
+    ///    to the field value. Otherwise, ignore the field.
+    ///
+    /// -> If the field name is "retry"
+    ///    If the field value consists of only ASCII digits, then interpret the field value as
+    ///    an integer in base ten, and set the event stream's reconnection time to that integer.
+    ///    Otherwise, ignore the field.
+    ///
+    /// -> Otherwise
+    ///    The field is treated as a custom event
+    ///    Set the event type buffer to the field name
+    ///    Set the data buffer to the field value
+    fn add(&mut self, line: RawEventLine) {
+        match line {
+            RawEventLine::Field(field, val) => {
+                let val = val.unwrap_or("");
+                match field {
+                    "event" => {
+                        self.event.event = val.to_string();
+                    }
+                    "data" => {
+                        self.event.data.push_str(val);
+                        self.event.data.push('\u{000A}');
+                    }
+                    "id" => {
+                        if !val.contains('\u{0000}') {
+                            self.event.id = val.to_string()
+                        }
+                    }
+                    "retry" => {
+                        if let Ok(val) = val.parse::<u64>() {
+                            self.event.retry = Some(Duration::from_millis(val))
+                        }
+                    }
+                    other => {
+                        self.event.event = other.to_string();
+                        self.event.data = val.to_string();
+                    }
+                }
+            }
+            RawEventLine::Comment(_) => {}
+            RawEventLine::Empty => self.is_complete = true,
+        }
+    }
+
+    fn dispatch(&mut self) -> Option<Event> {
+        let builder = core::mem::take(self);
+        let mut event = builder.event;
+        self.event.id = event.id.clone();
+
+        if event.data.is_empty() {
+            return None;
+        }
+
+        if is_lf(event.data.chars().next_back().unwrap()) {
+            event.data.pop();
+        }
+
+        if event.event.is_empty() {
+            event.event = "message".to_string();
+        }
+
+        Some(event)
+    }
+
+    fn is_complete(&self) -> bool {
+        self.is_complete
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let url = Url::parse("https://example.com").unwrap();
+    let response = Builder::new()
+        .status(200)
+        .url(url)
+        .body(
+            "
+data: {\"my\": \"data\"}
+
+custom_field: custom_data
+
+data: {\"my\": \"data2\"}
+
+different_field: different_data
+
+",
+        )
+        .unwrap();
+    let response = Response::from(response);
+    let mut stream = response
+        .bytes_stream()
+        .eventsource(CustomEventBuilder::default());
+
+    let event = stream.next().await.unwrap().unwrap();
+    assert_eq!("message", event.event);
+    assert_eq!("{\"my\": \"data\"}", event.data);
+
+    let event = stream.next().await.unwrap().unwrap();
+    assert_eq!("custom_field", event.event);
+    assert_eq!("custom_data", event.data);
+
+    let event = stream.next().await.unwrap().unwrap();
+    assert_eq!("message", event.event);
+    assert_eq!("{\"my\": \"data2\"}", event.data);
+
+    let event = stream.next().await.unwrap().unwrap();
+    assert_eq!("different_field", event.event);
+    assert_eq!("different_data", event.data);
+
+    let event = stream.next().await;
+    assert!(event.is_none());
+}

--- a/examples/request.rs
+++ b/examples/request.rs
@@ -1,4 +1,4 @@
-use eventsource_stream::Eventsource;
+use eventsource_stream::SpecCompliantEventsource;
 use futures::stream::StreamExt;
 use http::response::Builder;
 use reqwest::Response;
@@ -10,7 +10,7 @@ async fn main() {
     let url = Url::parse("https://example.com").unwrap();
     let response = Builder::new()
         .status(200)
-        .url(url.clone())
+        .url(url)
         .body(
             "event: my-event\r\ndata:line1
 data: line2
@@ -22,7 +22,7 @@ id: my-id
         )
         .unwrap();
     let response = Response::from(response);
-    let mut stream = response.bytes_stream().eventsource();
+    let mut stream = response.bytes_stream().spec_compliant_eventsource();
 
     let event = stream.next().await.unwrap().unwrap();
     assert_eq!("my-event", event.event);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,4 +38,7 @@ mod utf8_stream;
 
 pub use event::Event;
 pub use event_stream::{EventStream, EventStreamError};
-pub use traits::Eventsource;
+pub use parser::{
+    is_any_char, is_bom, is_colon, is_cr, is_lf, is_name_char, is_space, RawEventLine,
+};
+pub use traits::{EventBuilder, Eventsource, SpecCompliantEventsource};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,18 +1,38 @@
-use crate::event_stream::EventStream;
+pub use crate::event_stream::EventBuilder;
+use crate::event_stream::{EventStream, SpecCompliantEventBuilder};
 use futures_core::stream::Stream;
 
 /// Main entrypoint for creating [`crate::Event`] streams
-pub trait Eventsource: Sized {
+pub trait Eventsource<Builder>: Sized {
     /// Create an event stream from a stream of bytes
-    fn eventsource(self) -> EventStream<Self>;
+    fn eventsource(self, event_builder: Builder) -> EventStream<Self, Builder>;
 }
 
-impl<S, B, E> Eventsource for S
+/// Main entrypoint for creating [`crate::Event`] streams that are spec compliant
+///
+/// Fields ["id", "event", "data", "retry"] are populated from the stream of bytes,
+/// any other fields are ignored.
+pub trait SpecCompliantEventsource: Sized {
+    fn spec_compliant_eventsource(self) -> EventStream<Self, SpecCompliantEventBuilder>;
+}
+
+impl<S, B, E, Builder> Eventsource<Builder> for S
+where
+    S: Stream<Item = Result<B, E>>,
+    B: AsRef<[u8]>,
+    Builder: EventBuilder,
+{
+    fn eventsource(self, event_builder: Builder) -> EventStream<Self, Builder> {
+        EventStream::new(self, event_builder)
+    }
+}
+
+impl<S, B, E> SpecCompliantEventsource for S
 where
     S: Stream<Item = Result<B, E>>,
     B: AsRef<[u8]>,
 {
-    fn eventsource(self) -> EventStream<Self> {
-        EventStream::new(self)
+    fn spec_compliant_eventsource(self) -> EventStream<Self, SpecCompliantEventBuilder> {
+        EventStream::new(self, SpecCompliantEventBuilder::default())
     }
 }

--- a/tests/eventsource-stream.rs
+++ b/tests/eventsource-stream.rs
@@ -1,4 +1,7 @@
-use eventsource_stream::Eventsource;
+use std::time::Duration;
+
+use eventsource_stream::{is_lf, Event, EventBuilder, RawEventLine};
+use eventsource_stream::{Eventsource, SpecCompliantEventsource};
 use futures::stream::StreamExt;
 use http::response::Builder;
 use reqwest::Response;
@@ -29,7 +32,7 @@ data:ignored
         )
         .unwrap();
     let response = Response::from(response);
-    let mut stream = response.bytes_stream().eventsource();
+    let mut stream = response.bytes_stream().spec_compliant_eventsource();
 
     let event = stream.next().await.unwrap().unwrap();
     assert_eq!("my-event", event.event);
@@ -44,6 +47,137 @@ line2",
     let event = stream.next().await.unwrap().unwrap();
     assert_eq!("message", event.event);
     assert_eq!("second", event.data);
+
+    let event = stream.next().await;
+    assert!(event.is_none());
+}
+
+#[derive(Default, Debug)]
+pub struct CustomEventBuilder {
+    event: Event,
+    is_complete: bool,
+}
+
+impl EventBuilder for CustomEventBuilder {
+    /// From the HTML spec
+    ///
+    /// -> If the field name is "event"
+    ///    Set the event type buffer to field value.
+    ///
+    /// -> If the field name is "data"
+    ///    Append the field value to the data buffer, then append a single U+000A LINE FEED (LF)
+    ///    character to the data buffer.
+    ///
+    /// -> If the field name is "id"
+    ///    If the field value does not contain U+0000 NULL, then set the last event ID buffer
+    ///    to the field value. Otherwise, ignore the field.
+    ///
+    /// -> If the field name is "retry"
+    ///    If the field value consists of only ASCII digits, then interpret the field value as
+    ///    an integer in base ten, and set the event stream's reconnection time to that integer.
+    ///    Otherwise, ignore the field.
+    ///
+    /// -> Otherwise
+    ///    The field is treated as a custom event
+    ///    Set the event type buffer to the field name
+    ///    Set the data buffer to the field value
+    fn add(&mut self, line: RawEventLine) {
+        match line {
+            RawEventLine::Field(field, val) => {
+                let val = val.unwrap_or("");
+                match field {
+                    "event" => {
+                        self.event.event = val.to_string();
+                    }
+                    "data" => {
+                        self.event.data.push_str(val);
+                        self.event.data.push('\u{000A}');
+                    }
+                    "id" => {
+                        if !val.contains('\u{0000}') {
+                            self.event.id = val.to_string()
+                        }
+                    }
+                    "retry" => {
+                        if let Ok(val) = val.parse::<u64>() {
+                            self.event.retry = Some(Duration::from_millis(val))
+                        }
+                    }
+                    other => {
+                        self.event.event = other.to_string();
+                        self.event.data = val.to_string();
+                    }
+                }
+            }
+            RawEventLine::Comment(_) => {}
+            RawEventLine::Empty => self.is_complete = true,
+        }
+    }
+
+    fn dispatch(&mut self) -> Option<Event> {
+        let builder = core::mem::take(self);
+        let mut event = builder.event;
+        self.event.id = event.id.clone();
+
+        if event.data.is_empty() {
+            return None;
+        }
+
+        if is_lf(event.data.chars().next_back().unwrap()) {
+            event.data.pop();
+        }
+
+        if event.event.is_empty() {
+            event.event = "message".to_string();
+        }
+
+        Some(event)
+    }
+
+    fn is_complete(&self) -> bool {
+        self.is_complete
+    }
+}
+
+#[tokio::test]
+async fn populate_fields_non_compliant() {
+    let url = Url::parse("https://example.com").unwrap();
+    let response = Builder::new()
+        .status(200)
+        .url(url.clone())
+        .body(
+            "
+data: {\"my\": \"data\"}
+
+custom_field: custom_data
+
+data: {\"my\": \"data2\"}
+
+different_field: different_data
+
+",
+        )
+        .unwrap();
+    let response = Response::from(response);
+    let mut stream = response
+        .bytes_stream()
+        .eventsource(CustomEventBuilder::default());
+
+    let event = stream.next().await.unwrap().unwrap();
+    assert_eq!("message", event.event);
+    assert_eq!("{\"my\": \"data\"}", event.data);
+
+    let event = stream.next().await.unwrap().unwrap();
+    assert_eq!("custom_field", event.event);
+    assert_eq!("custom_data", event.data);
+
+    let event = stream.next().await.unwrap().unwrap();
+    assert_eq!("message", event.event);
+    assert_eq!("{\"my\": \"data2\"}", event.data);
+
+    let event = stream.next().await.unwrap().unwrap();
+    assert_eq!("different_field", event.event);
+    assert_eq!("different_data", event.data);
 
     let event = stream.next().await;
     assert!(event.is_none());


### PR DESCRIPTION
Make EventBuilder a trait, with a default SpecCompliantEventBuilder.

Allows for custom EventBuilders to handle RawEventLines which aren't apart of the HTML SSE event spec.
Not really the cleanest way to do this, but it's what I could think of doing now, would need to be a breaking change if upstreamed :(